### PR TITLE
Add env var to disable GAR blob bypass logic and let the proxy handle artifact downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,13 @@ environment variables:
 
 While deploying, you can set additional environment variables for customization:
 
-| Key | Value |
-|-----|-------|
-| `REGISTRY_HOST` | specify  hostname for target registry, e.g. `gcr.io`. |
-| `DISABLE_BROWSER_REDIRECTS` |  if you set this variable to any value,   visiting `example.com/image` on this browser will not redirect to  `[REGISTRY_HOST]/[REPO_PREFIX]/image` to allow your users to browse the image on GCR. If you're exposing private registries, you might want to set this variable. |
-| `AUTH_HEADER` | The `Authentication: [...]` header’s value to authenticate to the target registry |
-| `GOOGLE_APPLICATION_CREDENTIALS` | (For `gcr.io`) Path to the IAM service account JSON key  file to expose the private GCR registries publicly. |
+| Key                              | Value                                                                                                                                                                                                                                                                         |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `REGISTRY_HOST`                  | specify  hostname for target registry, e.g. `gcr.io`.                                                                                                                                                                                                                         |
+| `DISABLE_BROWSER_REDIRECTS`      | if you set this variable to any value,   visiting `example.com/image` on this browser will not redirect to  `[REGISTRY_HOST]/[REPO_PREFIX]/image` to allow your users to browse the image on GCR. If you're exposing private registries, you might want to set this variable. |
+| `DISABLE_GAR_BLOB_BYPASS`        | if you set this variable to any value,   layer blobs will be served via this proxy rather than directly from GAR. Note that this will incur more costs on Cloud Run such as networking egress and longer execution times leading to higher "billable time".                   |
+| `AUTH_HEADER`                    | The `Authentication: [...]` header’s value to authenticate to the target registry                                                                                                                                                                                             |
+| `GOOGLE_APPLICATION_CREDENTIALS` | (For `gcr.io`) Path to the IAM service account JSON key  file to expose the private GCR registries publicly.                                                                                                                                                                  |
 
 -----
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+	https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	re                 = regexp.MustCompile(`^/v2/`)
-	realm              = regexp.MustCompile(`realm="(.*?)"`)
+	re    = regexp.MustCompile(`^/v2/`)
+	realm = regexp.MustCompile(`realm="(.*?)"`)
 )
 
 type myContextKey string
@@ -53,6 +53,7 @@ func main() {
 		log.Fatal("PORT environment variable not specified")
 	}
 	browserRedirects := os.Getenv("DISABLE_BROWSER_REDIRECTS") == ""
+	bypassGARBlobs := os.Getenv("DISABLE_GAR_BLOB_BYPASS") == ""
 
 	registryHost := os.Getenv("REGISTRY_HOST")
 	if registryHost == "" {
@@ -93,7 +94,10 @@ func main() {
 	if tokenEndpoint != "" {
 		mux.Handle("/_token", tokenProxyHandler(tokenEndpoint, repoPrefix))
 	}
-	mux.Handle("/v2/", registryAPIProxy(reg, auth))
+	mux.Handle("/v2/", registryAPIProxy(reg, auth, bypassGARBlobs))
+	if !bypassGARBlobs {
+		mux.Handle("/artifacts-downloads/", artifactRegistryBlobProxy(reg))
+	}
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	handler := captureHostHeader(mux)
@@ -174,12 +178,13 @@ func browserRedirectHandler(cfg registryConfig) http.HandlerFunc {
 }
 
 // registryAPIProxy returns a reverse proxy to the specified registry.
-func registryAPIProxy(cfg registryConfig, auth authenticator) http.HandlerFunc {
+func registryAPIProxy(cfg registryConfig, auth authenticator, bypassGARBlobs bool) http.HandlerFunc {
 	return (&httputil.ReverseProxy{
 		FlushInterval: -1,
 		Director:      rewriteRegistryV2URL(cfg),
 		Transport: &registryRoundtripper{
-			auth: auth,
+			auth:           auth,
+			bypassGARBlobs: bypassGARBlobs,
 		},
 	}).ServeHTTP
 }
@@ -199,8 +204,26 @@ func rewriteRegistryV2URL(c registryConfig) func(*http.Request) {
 	}
 }
 
+func artifactRegistryBlobProxy(cfg registryConfig) http.HandlerFunc {
+	return (&httputil.ReverseProxy{
+		FlushInterval: -1,
+		Director:      rewriteArtifactRegistryBlobURL(cfg),
+	}).ServeHTTP
+}
+
+func rewriteArtifactRegistryBlobURL(c registryConfig) func(*http.Request) {
+	return func(req *http.Request) {
+		u := req.URL.String()
+		req.Host = c.host
+		req.URL.Scheme = "https"
+		req.URL.Host = c.host
+		log.Printf("rewrote blob url: %s into %s", u, req.URL)
+	}
+}
+
 type registryRoundtripper struct {
-	auth authenticator
+	auth           authenticator
+	bypassGARBlobs bool
 }
 
 func (rrt *registryRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -223,11 +246,13 @@ func (rrt *registryRoundtripper) RoundTrip(req *http.Request) (*http.Response, e
 		return nil, err
 	}
 
-	// Google Artifact Registry sends a "location: /artifacts-downloads/..." URL
-	// to download blobs. We don't want these routed to the proxy itself.
-	if locHdr := resp.Header.Get("location"); req.Method == http.MethodGet &&
-		resp.StatusCode == http.StatusFound && strings.HasPrefix(locHdr, "/") {
-		resp.Header.Set("location", req.URL.Scheme+"://"+req.URL.Host+locHdr)
+	if rrt.bypassGARBlobs {
+		// Google Artifact Registry sends a "location: /artifacts-downloads/..." URL
+		// to download blobs. We don't want these routed to the proxy itself.
+		if locHdr := resp.Header.Get("location"); req.Method == http.MethodGet &&
+			resp.StatusCode == http.StatusFound && strings.HasPrefix(locHdr, "/") {
+			resp.Header.Set("location", req.URL.Scheme+"://"+req.URL.Host+locHdr)
+		}
 	}
 
 	updateTokenEndpoint(resp, origHost)
@@ -235,7 +260,9 @@ func (rrt *registryRoundtripper) RoundTrip(req *http.Request) (*http.Response, e
 }
 
 // updateTokenEndpoint modifies the response header like:
-//    Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io"
+//
+//	Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io"
+//
 // to point to the https://host/token endpoint to force using local token
 // endpoint proxy.
 func updateTokenEndpoint(resp *http.Response, host string) {


### PR DESCRIPTION
Adds an optional env var DISABLE_GAR_BLOB_BYPASS which can be used to force the blob downloads through the proxy.
This is required in scenarios where general internet access is restricted and ALL traffic must flow through the proxy server.

Merging onto forked master since this PR was declined in https://github.com/ahmetb/serverless-registry-proxy/pull/47 due to it not being a widely required feature.